### PR TITLE
Updated visualisation with parser argument

### DIFF
--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -1,6 +1,6 @@
 import cv2
 
-def draw_annotations(frame, tracked_people, poses, body_part_boxes, person_interactions, current_pids):
+def draw_annotations(frame, tracked_people, poses, body_part_boxes, person_interactions, current_pids,boxes,frame_width,frame_height):
     """
     Draw annotations on the video frame.
     
@@ -42,5 +42,14 @@ def draw_annotations(frame, tracked_people, poses, body_part_boxes, person_inter
             for obj_label in interacted_objects:
                 action = f"P{person_id} working with {obj_label}"
                 cv2.putText(frame, action, (x1, y1 - 25), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 0), 2)
+
+    # Draw labelled kitchen object boxes
+    for box in boxes:
+        points_abs = [(int(x * frame_width), int(y * frame_height)) for x, y in box['points']]
+        for i in range(len(points_abs)):
+            cv2.line(frame, points_abs[i], points_abs[(i + 1) % len(points_abs)], (0, 255, 0), 2)
+        cv2.putText(frame, box['label'], points_abs[0], 
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+
     
     return frame


### PR DESCRIPTION
# 👮 Pull Request Checklist

## 📝 Description

This PR updates `main.py` and `visulisation.py` for:

- Set `--generate_video` default to `False` with `action="store_true"`, enabling video generation only when the flag is included.
- Return boxes from `load_object_coordinates` in the main function for use in the main file.
- Draw object coordinates (green polygons and labels) in `draw_annotations` when `--generate_video` is used. Default is False.

---

  **Testing Info**:  
  Run:

  ```bash
  python main.py --video_folder data/videos --class_json data/class-1.json --cord_txt data/cord-1.txt --generate_video
  ```


## Video Output

- https://drive.google.com/drive/folders/1SqimFPkkphV58luQ-Qu4I9bWUAUx2rpK?usp=drive_link

